### PR TITLE
chore(ci): Prevent failing particular OS builds from cancelling other OS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
 
     # Platforms to build on/for
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
 


### PR DESCRIPTION
Mac builds are being cancelled by Windows build failure.