### PR TITLE
chore(ci): Use node@16 in all GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Install project dependencies
         if: steps.yarn-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Install project dependencies
         if: steps.yarn-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Tests would fail due to unsupported node version (12) for newer versions of `electron-builder` (v23), or something like that.