### PR TITLE
Pass GH_PANERON_CI_TOKEN via env var

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -59,3 +59,5 @@ jobs:
     # Update the website to show new version.
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     uses: ./.github/workflows/update-website.yml
+    secrets:
+      GH_PANERON_CI_TOKEN: ${{ secrets.GH_PANERON_CI_TOKEN }}

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -59,5 +59,4 @@ jobs:
     # Update the website to show new version.
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     uses: ./.github/workflows/update-website.yml
-    secrets:
-      GH_PANERON_CI_TOKEN: ${{ secrets.GH_PANERON_CI_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -64,7 +64,8 @@ jobs:
     # If the commit is tagged with a version (e.g. "v1.0.0"),
     # that means a new release has been created.
     # Update the website to show new version.
-    # if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     uses: ./.github/workflows/update-website.yml
     secrets:
       GH_PANERON_CI_TOKEN: ${{ secrets.GH_PANERON_CI_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -66,6 +66,4 @@ jobs:
     # Update the website to show new version.
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     uses: ./.github/workflows/update-website.yml
-    secrets:
-      GH_PANERON_CI_TOKEN: ${{ secrets.GH_PANERON_CI_TOKEN }}
     secrets: inherit

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -64,5 +64,7 @@ jobs:
     # If the commit is tagged with a version (e.g. "v1.0.0"),
     # that means a new release has been created.
     # Update the website to show new version.
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    # if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     uses: ./.github/workflows/update-website.yml
+    secrets:
+      GH_PANERON_CI_TOKEN: ${{ secrets.GH_PANERON_CI_TOKEN }}

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -20,6 +20,9 @@ jobs:
             -X POST \
             --fail-with-body \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GH_PANERON_CI_TOKEN }}" \
+            -H "Authorization: Bearer ${GH_PANERON_CI_TOKEN}" \
             https://api.github.com/repos/paneron/extensions.paneron.org/dispatches \
             -d '{"event_type":"update-website","client_payload":{}}'
+        env:
+          GH_PANERON_CI_TOKEN: ${{ secrets.GH_PANERON_CI_TOKEN }}
+

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -9,10 +9,6 @@ jobs:
     name: Trigger website build
     runs-on: ubuntu-latest
 
-    concurrency:
-      group: '${{ github.workflow }}-${{ github.head_ref || github.ref_name }}'
-      cancel-in-progress: true
-
     steps:
       - name: Dispatch update-website event
         run: |

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -2,6 +2,9 @@ name: update-website
 
 on:
   workflow_call:
+    secrets:
+      GH_PANERON_CI_TOKEN:
+        required: true
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -2,9 +2,6 @@ name: update-website
 
 on:
   workflow_call:
-    secrets:
-      GH_PANERON_CI_TOKEN:
-        required: true
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -59,3 +59,5 @@ jobs:
     # Update the website to show new version.
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     uses: ./.github/workflows/update-website.yml
+    secrets:
+      GH_PANERON_CI_TOKEN: ${{ secrets.GH_PANERON_CI_TOKEN }}

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -59,5 +59,4 @@ jobs:
     # Update the website to show new version.
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     uses: ./.github/workflows/update-website.yml
-    secrets:
-      GH_PANERON_CI_TOKEN: ${{ secrets.GH_PANERON_CI_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
Per https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow

> If you must pass secrets within a command line, then enclose them within the proper quoting rules. Secrets often contain special characters that may unintentionally affect your shell. To escape these special characters, use quoting with your environment variables